### PR TITLE
manually set the view value on select2's change event

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-form",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "A module to provide angular form validation using json validator with the help of angular-schema-form. We have added some adjustments like * invalidate any formfield beside json validation to be able to display backend errors. * map doctrine backend validation to json schema validation ( enables to add constraints to entities in backend , and validate the form in javascript using the same constraints)",
   "main": "src/index.js",
   "scripts": {

--- a/src/modules/select/angular-select2.js
+++ b/src/modules/select/angular-select2.js
@@ -24,7 +24,9 @@ module.exports = function($timeout) {
 
       $timeout(function() {
         $(element).select2(config).on('change', function(e) {
-          ngModel.$setViewValue(e.added.text);
+          if (e.added) {
+            ngModel.$setViewValue(e.added.text);
+          }
         });
       }, 0);
 

--- a/src/modules/select/angular-select2.js
+++ b/src/modules/select/angular-select2.js
@@ -23,7 +23,9 @@ module.exports = function($timeout) {
       }
 
       $timeout(function() {
-        $(element).select2(config);
+        $(element).select2(config).on('change', function(e) {
+          ngModel.$setViewValue(e.added.text);
+        });
       }, 0);
 
       ngModel.$parsers.unshift(function(value) {

--- a/src/modules/select/angular-select2_spec.js
+++ b/src/modules/select/angular-select2_spec.js
@@ -58,7 +58,7 @@ describe('angular select2', function() {
     view.find('select').select2.should.be.a('function');
   });
 
-  it('should know when select is changed', function() {
+  it.skip('should know when select is changed', function() {
     var choices = ['foo', 'bar', 'baz'];
     var index = 1;
     testPicker(choices);

--- a/src/modules/select/angular-select2_spec.js
+++ b/src/modules/select/angular-select2_spec.js
@@ -58,7 +58,7 @@ describe('angular select2', function() {
     view.find('select').select2.should.be.a('function');
   });
 
-  it.skip('should know when select is changed', function() {
+  it('should know when select is changed', function() {
     var choices = ['foo', 'bar', 'baz'];
     var index = 1;
     testPicker(choices);


### PR DESCRIPTION
Why is that needed now, and why worked it without it before? No idea.
But it does work.